### PR TITLE
OCR Improvements

### DIFF
--- a/Scripts/1.ahk
+++ b/Scripts/1.ahk
@@ -3565,13 +3565,10 @@ getChangeDateTime() {
 }
 
 
-/*
 ^e::
-    msgbox ss
     pToken := Gdip_Startup()
-    Screenshot()
+    Screenshot_dev()
 return
-*/
 
 ; ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ; Find Card Count and Relevant Functions


### PR DESCRIPTION
Fixed an issue with temp PACKSTATS screenshots not deleting

Tightened regex more for refined OCR retries

Adopted gdipinclude for more accurate OCR (ty to gptest)