### PR TITLE
Skip final pack open animation while leveling

### DIFF
--- a/Scripts/1.ahk
+++ b/Scripts/1.ahk
@@ -2913,10 +2913,6 @@ DoTutorial() {
     adbClick_wbb(140, 424)
 
     FindImageAndClick(225, 273, 235, 290, , "Pack", 140, 424) ;wait for pack to be ready  to trace
-        if(FastOpeningConditions()) {
-            CreateStatusMessage("Final pack #" . (packs + 1) . "; skipping animations.",,,, false)
-            return ; if leveling accounts without GP search, skip final pack opening animation
-        }
         if(setSpeed > 1) {
             FindImageAndClick(65, 195, 100, 215, , "Platin", 18, 109, 2000) ; click mod settings
             FindImageAndClick(9, 170, 25, 190, , "One", 26, 180) ; click mod settings
@@ -3012,10 +3008,6 @@ DoTutorial() {
     adbClick_wbb(142, 436)
 
     FindImageAndClick(225, 273, 235, 290, , "Pack", 239, 497) ;wait for pack to be ready  to Trace
-        if(FastOpeningConditions()) {
-            CreateStatusMessage("Final pack #" . (packs + 1) . "; skipping animations.",,,, false)
-            return ; if leveling accounts without GP search, skip final pack opening animation
-        }
         if(setSpeed > 1) {
             FindImageAndClick(65, 195, 100, 215, , "Platin", 18, 109, 2000) ; click mod settings
             FindImageAndClick(9, 170, 25, 190, , "One", 26, 180) ; click mod settings
@@ -3263,6 +3255,10 @@ PackOpening() {
         if(failSafeTime > 45)
             restartGameInstance("Stuck at Pack")
     }
+    if(FastOpeningConditions()) {
+        CreateStatusMessage("Final pack #" . (packs + 1) . "; skipping animations.",,,, false)
+        return ; if leveling accounts without GP search, skip final pack opening animation
+    }
 
     if(setSpeed > 1) {
     FindImageAndClick(65, 195, 100, 215, , "Platin", 18, 109, 2000) ; click mod settings
@@ -3385,6 +3381,10 @@ HourglassOpening(HG := false) {
         CreateStatusMessage("Waiting for Pack`n(" . failSafeTime . "/45 seconds)")
         if(failSafeTime > 45)
             restartGameInstance("Stuck at Pack")
+    }
+    if(FastOpeningConditions()) {
+        CreateStatusMessage("Final pack #" . (packs + 1) . "; skipping animations.",,,, false)
+        return ; if leveling accounts without GP search, skip final pack opening animation
     }
 
     if(setSpeed > 1) {

--- a/Scripts/1.ahk
+++ b/Scripts/1.ahk
@@ -2913,6 +2913,10 @@ DoTutorial() {
     adbClick_wbb(140, 424)
 
     FindImageAndClick(225, 273, 235, 290, , "Pack", 140, 424) ;wait for pack to be ready  to trace
+        if(FastOpeningConditions()) {
+            CreateStatusMessage("Final pack #" . (packs + 1) . "; skipping animations.",,,, false)
+            return ; if leveling accounts without GP search, skip final pack opening animation
+        }
         if(setSpeed > 1) {
             FindImageAndClick(65, 195, 100, 215, , "Platin", 18, 109, 2000) ; click mod settings
             FindImageAndClick(9, 170, 25, 190, , "One", 26, 180) ; click mod settings
@@ -3008,6 +3012,10 @@ DoTutorial() {
     adbClick_wbb(142, 436)
 
     FindImageAndClick(225, 273, 235, 290, , "Pack", 239, 497) ;wait for pack to be ready  to Trace
+        if(FastOpeningConditions()) {
+            CreateStatusMessage("Final pack #" . (packs + 1) . "; skipping animations.",,,, false)
+            return ; if leveling accounts without GP search, skip final pack opening animation
+        }
         if(setSpeed > 1) {
             FindImageAndClick(65, 195, 100, 215, , "Platin", 18, 109, 2000) ; click mod settings
             FindImageAndClick(9, 170, 25, 190, , "One", 26, 180) ; click mod settings
@@ -3430,6 +3438,22 @@ HourglassOpening(HG := false) {
         if(failSafeTime > 45)
             restartGameInstance("Stuck at ConfirmPack")
     }
+}
+
+FastOpeningConditions() {
+    ; Check if we're about to open the last pack of current run.
+    ; (Called in PackOpening and HourglassOpening to skip last pack animation by ending run early.)
+    global getFC, friendIDs, friendID, deleteMethod, packs
+
+    if (!getFC && !friendIDs && friendID = "") {
+        if ((deleteMethod = "5 Pack" && packs = 4) ; currently broken due to 5-pack counter getting reset from 3 to 0 in CheckPack()
+            || (deleteMethod = "13 Pack" && packs = 12)
+            || (deleteMethod = "Inject" && packs = 1)
+            || (deleteMethod = "Inject 10P" && packs = 9)) {
+            return true
+        }
+    }
+    return false
 }
 
 getFriendCode() {


### PR DESCRIPTION
Added a helper function FastOpeningConditions to check if user is leveling their accounts (no account IDs to add as friends), and checks if the current pack being opened is the last expected pack during this run (e.g. if this is the pack 2 out of 2 for Inject 2P mode, or 13th out of 13 packs while user is running "13 Pack" method.)

This function is called in PackOpening and HourglassOpening to return early out of those functions if FastOpeningConditions are met. With current main loop setup, this will skip opening / sorting final pack sequence and move onto a new run. 

Two potential issues:
1) Users may report this as a bug, as any status message created during this step of PackOpening will be quickly cleared by the loading account message, and closing the game at this point might appear as a bug to many users. Potential solutions are to wait for after pack swipe (to make it clearer to user the bot did open the pack), or to add early CreateStatusMessage within SelectPack to check for this same FastOpeningConditions to help explain to users ahead of time what PackOpening is about to do (skip opening animation.)

2) The current placement in main loop and the "return" command works right now, but if any features are added to click around after completing all PackOpening in the future, this feature could get stuck. This is easily fixed in the future

One current issue:
"5 Pack" opening method currently resets "packs" counter from 3 down to 0. I don't have the history as to why, but it's preventing us from using the "packs" counter to detect 5th out of 5 packs for this method to return from PackOpening early. I could create a workaround if needed, but it seems like this 5 Pack packs counter could be fixed instead with a better method, or we can just leave it out as it's only a minor improvement in speed.