### PR TITLE
Skip final pack opening animation when leveling accounts

### DIFF
--- a/Scripts/1.ahk
+++ b/Scripts/1.ahk
@@ -3450,8 +3450,10 @@ fastOpeningConditions() {
             || (deleteMethod = "13 Pack" && packs = 12) ; if packs = 12 then we have already opened 12, so this is our 13th
             || (deleteMethod = "Inject" && packs = 1 && loadedAccount)
             || (deleteMethod = "Inject 10P" && packs = 9 && loadedAccount)) 
-            || (deleteMethod = "Inject" || "Inject 10P" && packs = 2 && !loadedAccount) { ; if injecting but no account is loaded, then we made a new account and should fast-open pack #3 instead of pack #2 (Inject) or #10 (Inject 10P)
-            return true
+            || (deleteMethod = "Inject" && packs = 2 && !loadedAccount) { ; if injecting but no account is loaded, then we made a new account and should fast-open pack #3 instead of pack #2 (Inject) or #10 (Inject 10P)
+            || (deleteMethod = "Inject 10P" && packs = 2 && !loadedAccount) { ; if injecting but no account is loaded, then we made a new account and should fast-open pack #3 instead of pack #2 (Inject) or #10 (Inject 10P)
+
+                return true
         }
     }
     return false

--- a/Scripts/1.ahk
+++ b/Scripts/1.ahk
@@ -3446,10 +3446,11 @@ fastOpeningConditions() {
     global getFC, friendIDs, friendID, deleteMethod, packs
 
     if (!getFC && !friendIDs && friendID = "") {
-        if ((deleteMethod = "5 Pack" && packs = 4) ; currently broken due to 5-pack counter getting reset from 3 to 0 in CheckPack()
-            || (deleteMethod = "13 Pack" && packs = 12)
+        if ((deleteMethod = "5 Pack" && packs = 4) ; "5 Pack" fast opening is currently broken due to packs counter getting reset from 3 to 0 in CheckPack() with current logic
+            || (deleteMethod = "13 Pack" && packs = 12) ; if packs = 12 then we have already opened 12, so this is our 13th
             || (deleteMethod = "Inject" && packs = 1 && loadedAccount)
-            || (deleteMethod = "Inject 10P" && packs = 9 && loadedAccount)) {
+            || (deleteMethod = "Inject 10P" && packs = 9 && loadedAccount)) 
+            || (deleteMethod = "Inject" || "Inject 10P" && packs = 2 && !loadedAccount) { ; if injecting but no account is loaded, then we made a new account and should fast-open pack #3 instead of pack #2 (Inject) or #10 (Inject 10P)
             return true
         }
     }

--- a/Scripts/1.ahk
+++ b/Scripts/1.ahk
@@ -3449,9 +3449,9 @@ fastOpeningConditions() {
         if ((deleteMethod = "5 Pack" && packs = 4) ; "5 Pack" fast opening is currently broken due to packs counter getting reset from 3 to 0 in CheckPack() with current logic
             || (deleteMethod = "13 Pack" && packs = 12) ; if packs = 12 then we have already opened 12, so this is our 13th
             || (deleteMethod = "Inject" && packs = 1 && loadedAccount)
-            || (deleteMethod = "Inject 10P" && packs = 9 && loadedAccount)) 
-            || (deleteMethod = "Inject" && packs = 2 && !loadedAccount) { ; if injecting but no account is loaded, then we made a new account and should fast-open pack #3 instead of pack #2 (Inject) or #10 (Inject 10P)
-            || (deleteMethod = "Inject 10P" && packs = 2 && !loadedAccount) { ; if injecting but no account is loaded, then we made a new account and should fast-open pack #3 instead of pack #2 (Inject) or #10 (Inject 10P)
+            || (deleteMethod = "Inject 10P" && packs = 9 && loadedAccount)
+            || (deleteMethod = "Inject" && packs = 2 && !loadedAccount) ; if injecting but no account is loaded, then we made a new account and should fast-open pack #3 instead of pack #2 (Inject) or #10 (Inject 10P)
+            || (deleteMethod = "Inject 10P" && packs = 2 && !loadedAccount)) { ; if injecting but no account is loaded, then we made a new account and should fast-open pack #3 instead of pack #2 (Inject) or #10 (Inject 10P)
 
                 return true
         }

--- a/Scripts/1.ahk
+++ b/Scripts/1.ahk
@@ -3255,7 +3255,7 @@ PackOpening() {
         if(failSafeTime > 45)
             restartGameInstance("Stuck at Pack")
     }
-    if(FastOpeningConditions()) {
+    if(fastOpeningConditions()) {
         CreateStatusMessage("Final pack #" . (packs + 1) . "; skipping animations.",,,, false)
         return ; if leveling accounts without GP search, skip final pack opening animation
     }
@@ -3382,7 +3382,7 @@ HourglassOpening(HG := false) {
         if(failSafeTime > 45)
             restartGameInstance("Stuck at Pack")
     }
-    if(FastOpeningConditions()) {
+    if(fastOpeningConditions()) {
         CreateStatusMessage("Final pack #" . (packs + 1) . "; skipping animations.",,,, false)
         return ; if leveling accounts without GP search, skip final pack opening animation
     }
@@ -3440,7 +3440,7 @@ HourglassOpening(HG := false) {
     }
 }
 
-FastOpeningConditions() {
+fastOpeningConditions() {
     ; Check if we're about to open the last pack of current run.
     ; (Called in PackOpening and HourglassOpening to skip last pack animation by ending run early.)
     global getFC, friendIDs, friendID, deleteMethod, packs
@@ -3448,8 +3448,8 @@ FastOpeningConditions() {
     if (!getFC && !friendIDs && friendID = "") {
         if ((deleteMethod = "5 Pack" && packs = 4) ; currently broken due to 5-pack counter getting reset from 3 to 0 in CheckPack()
             || (deleteMethod = "13 Pack" && packs = 12)
-            || (deleteMethod = "Inject" && packs = 1)
-            || (deleteMethod = "Inject 10P" && packs = 9)) {
+            || (deleteMethod = "Inject" && packs = 1 && loadedAccount)
+            || (deleteMethod = "Inject 10P" && packs = 9 && loadedAccount)) {
             return true
         }
     }

--- a/Scripts/1.ahk
+++ b/Scripts/1.ahk
@@ -3255,6 +3255,10 @@ PackOpening() {
         if(failSafeTime > 45)
             restartGameInstance("Stuck at Pack")
     }
+    if(FastOpeningConditions()) {
+        CreateStatusMessage("Final pack #" . (packs + 1) . "; skipping animations.",,,, false)
+        return ; if leveling accounts without GP search, skip final pack opening animation
+    }
 
     if(setSpeed > 1) {
     FindImageAndClick(65, 195, 100, 215, , "Platin", 18, 109, 2000) ; click mod settings
@@ -3378,6 +3382,10 @@ HourglassOpening(HG := false) {
         if(failSafeTime > 45)
             restartGameInstance("Stuck at Pack")
     }
+    if(FastOpeningConditions()) {
+        CreateStatusMessage("Final pack #" . (packs + 1) . "; skipping animations.",,,, false)
+        return ; if leveling accounts without GP search, skip final pack opening animation
+    }
 
     if(setSpeed > 1) {
     FindImageAndClick(65, 195, 100, 215, , "Platin", 18, 109, 2000) ; click mod settings
@@ -3430,6 +3438,22 @@ HourglassOpening(HG := false) {
         if(failSafeTime > 45)
             restartGameInstance("Stuck at ConfirmPack")
     }
+}
+
+FastOpeningConditions() {
+    ; Check if we're about to open the last pack of current run.
+    ; (Called in PackOpening and HourglassOpening to skip last pack animation by ending run early.)
+    global getFC, friendIDs, friendID, deleteMethod, packs
+
+    if (!getFC && !friendIDs && friendID = "") {
+        if ((deleteMethod = "5 Pack" && packs = 4) ; currently broken due to 5-pack counter getting reset from 3 to 0 in CheckPack()
+            || (deleteMethod = "13 Pack" && packs = 12)
+            || (deleteMethod = "Inject" && packs = 1)
+            || (deleteMethod = "Inject 10P" && packs = 9)) {
+            return true
+        }
+    }
+    return false
 }
 
 getFriendCode() {
@@ -3806,5 +3830,3 @@ GetTextFromBitmap(pBitmap, charAllowList := "") {
 RegExEscape(str) {
     return RegExReplace(str, "([-[\]{}()*+?.,\^$|#\s])", "\$1")
 }
-
-


### PR DESCRIPTION
Created FastOpeningConditions helper function to detect if we are leveling accoutns (not adding friends) and if we are about to open our final pack of this run (e.g. 10th pack during "Inject 10P" deleteMethod.)

Called in PackOpening and HourglassOpening to return out of these functions if this is the final pack.

Known issues:

1. Disabled for "5 Pack" deleteMethod as current 1.ahk resets "packs" counter from "= 3", to "= 0".

2. Users may report this feature as a bug since it looks weird. Possible solution is to call this fastOpeningConditions within SelectPack to warn users with CreateStatusMessage that the bot is about to skip the final pack opening animations before New Run.